### PR TITLE
Xvfb warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,8 @@ Usage
 
 With Xvfb and the plugin installed, your testsuite automatically runs with `Xvfb`_. This allows tests to be run without windows popping up during GUI tests or on systems without a display (like a CI).
 
-If Xvfb is not installed, the plugin does not run and your tests will still work as normal.
+If Xvfb is not installed, the plugin does not run and your tests will still work as normal. However,
+a warning message will print to standard output letting you know that Xvfb is not installed.
 
 If you're currently using ``xvfb-run`` in something like ``.travis.yml``,
 simply remove it and install this plugin instead - then you'll also have the

--- a/pytest_xvfb.py
+++ b/pytest_xvfb.py
@@ -8,6 +8,7 @@ import fnmatch
 import hashlib
 import tempfile
 import subprocess
+import sys
 
 import pytest
 
@@ -132,6 +133,11 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     if config.getoption('--no-xvfb') or not xvfb_available():
         config.xvfb = None
+        if (sys.platform.startswith('linux')
+                and 'DISPLAY' in os.environ
+                and not config.getoption('--no-xvfb')):
+            print('pytest-xvfb could not find Xvfb. '
+                  'You can install it to prevent windows from being shown.')
     else:
         config.xvfb = Xvfb(config)
         config.xvfb.start()

--- a/tests/test_xvfb.py
+++ b/tests/test_xvfb.py
@@ -55,6 +55,7 @@ def test_xvfb_unavailable(testdir, monkeypatch):
     """)
     assert os.environ['DISPLAY'] == ':42'
     result = testdir.runpytest()
+    result.stdout.fnmatch_lines('* could not find Xvfb.*')
     assert result.ret == 0
 
 
@@ -142,7 +143,7 @@ def test_no_xvfb_marker(testdir, args, outcome):
             pass
     """)
     res = testdir.runpytest(*args)
-    res.stdout.fnmatch_lines('*= {0} in *'.format(outcome))
+    res.stdout.fnmatch_lines('*= {0}*'.format(outcome))
 
 
 def test_xvfb_fixture(testdir):


### PR DESCRIPTION
This issue fixes #2 pertaining to an Xvfb warning. I added a pytest warning in pytest_configure, additional information in the readme, and a test that checks to make sure pytest.warns works as expected. The only thing I was't sure how to test was whether or not the warning displays in the test_xvfb_unavailable function.
