### PR TITLE
Switch to pyvirtualdisplay

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='A pytest plugin to run Xvfb for tests.',
     long_description=read('README.rst'),
     py_modules=['pytest_xvfb'],
-    install_requires=['pytest>=2.8.1'],
+    install_requires=['pytest>=2.8.1', 'pyvirtualdisplay>=0.2.1'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,7 @@
 envlist = py27,py33,py34,py35,pypy
 
 [testenv]
-deps = pytest
+deps =
+     pytest
+     pyvirtualdisplay
 commands = py.test {posargs:tests}


### PR DESCRIPTION
Fixes #4

This removes a lot of the handling code that we had, because everything
Xvfb and xauth related is now done by pyvirtualdisplay. We just have to
pass the right parameters and start()/stop() the display.