### PR TITLE
Improve content of PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include CHANGELOG.rst
+recursive-include tests *.py


### PR DESCRIPTION
This commit adds the change log and test suite to the tarball produced by `sdist`, which is recommended for Linux packaging downstream. Please consider merging this proposal, followed by an upload of a new release to PyPI.