### PR TITLE
Include LICENSE file into sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include CHANGELOG.rst
+include LICENSE
 recursive-include tests *.py


### PR DESCRIPTION
Notice this while building the [conda package](https://github.com/conda-forge/pytest-xvfb-feedstock/pull/5/files).